### PR TITLE
hタグ用コンポーネント作成

### DIFF
--- a/src/@types/theme.d.ts
+++ b/src/@types/theme.d.ts
@@ -14,6 +14,10 @@ declare module '@emotion/react' {
       text: {
         primary: string
         secondary: string
+        tertiary: string
+        quaternary: string
+        quinary: string
+        senary: string
       }
     }
     margin: {

--- a/src/components/errors/ErrorFallback.tsx
+++ b/src/components/errors/ErrorFallback.tsx
@@ -1,11 +1,13 @@
 import { FC } from 'react'
 import { FallbackProps } from 'react-error-boundary'
 
+import { Head } from '../parts/texts/Head'
+
 export const ErrorFallback: FC<FallbackProps> = ({ error }) => {
   console.log('boundary error', error)
   return (
     <div>
-      <h2>エラーが発生しました。</h2>
+      <Head level={2}>エラーが発生しました。</Head>
       <pre>{error.message}</pre>
     </div>
   )

--- a/src/components/parts/texts/Head.tsx
+++ b/src/components/parts/texts/Head.tsx
@@ -1,0 +1,24 @@
+import { ElementType, FC, HTMLAttributes, memo, ReactNode } from 'react'
+
+interface Props extends HTMLAttributes<HTMLHeadingElement> {
+  level: 1 | 2 | 3 | 4 | 5 | 6
+  children: ReactNode
+}
+
+const BeforeMemoHead: FC<Props> = ({
+  level,
+  children,
+  className,
+  ...props
+}) => {
+  const HeadTag = `h${level}` as ElementType
+
+  return (
+    <HeadTag className={className} {...props}>
+      {children}
+    </HeadTag>
+  )
+}
+
+export const Head = memo(BeforeMemoHead)
+Head.displayName = 'Head'

--- a/src/components/template/layouts/Footer.tsx
+++ b/src/components/template/layouts/Footer.tsx
@@ -6,11 +6,14 @@ import {
   footerStyle,
   footerTitleStyle,
 } from '../../../styles/layouts/footer'
+import { Head } from '../../parts/texts/Head'
 
 export const Footer: FC = () => {
   return (
     <footer css={footerStyle}>
-      <h1 css={footerTitleStyle}>{CONST_DATA.APP_TITLE}</h1>
+      <Head level={2} css={footerTitleStyle}>
+        {CONST_DATA.APP_TITLE}
+      </Head>
       <p css={footerCopyrightStyle}>&copy;manne Inc.</p>
     </footer>
   )

--- a/src/components/template/layouts/Header.tsx
+++ b/src/components/template/layouts/Header.tsx
@@ -1,13 +1,13 @@
 import clsx from 'clsx'
 import { FC, memo } from 'react'
 
+import { Head } from '../../parts/texts/Head'
+import { CONST_DATA } from '../../../const'
 // TODO: useDisclosure
 import { useDiscloser } from '../../../hooks/useDisclosur'
-import { CONST_DATA } from '../../../const'
 import {
   headerNavStyle,
   headerStyle,
-  headerTitleStyle,
   openBtnStyle,
 } from '../../../styles/layouts/header'
 
@@ -18,7 +18,7 @@ export const Header: FC = memo(() => {
   return (
     <header css={headerStyle}>
       <div>
-        <h1 css={headerTitleStyle}>{CONST_DATA.APP_TITLE}</h1>
+        <Head level={1}>{CONST_DATA.APP_TITLE}</Head>
         <nav css={headerNavStyle}>
           {/* TODO: PCメニュー */}
           <div

--- a/src/components/template/layouts/Header.tsx
+++ b/src/components/template/layouts/Header.tsx
@@ -1,6 +1,7 @@
 import clsx from 'clsx'
 import { FC, memo } from 'react'
 
+// TODO: useDisclosure
 import { useDiscloser } from '../../../hooks/useDisclosur'
 import { CONST_DATA } from '../../../const'
 import {
@@ -11,6 +12,7 @@ import {
 } from '../../../styles/layouts/header'
 
 export const Header: FC = memo(() => {
+  // TODO: useDisclosure
   const { isOpen, handleToggle } = useDiscloser()
 
   return (

--- a/src/hooks/useDisclosur.ts
+++ b/src/hooks/useDisclosur.ts
@@ -8,6 +8,7 @@ interface ReturnProp {
 }
 
 // TODO: 5. メモ化
+// TODO: useDisclosure
 export const useDiscloser = (): ReturnProp => {
   // TODO: 1. isOpen stateを定義しよう
   const [isOpen, setIsOpen] = useState(false)

--- a/src/pages/Auth.tsx
+++ b/src/pages/Auth.tsx
@@ -1,7 +1,9 @@
 import { FC, useState } from 'react'
+
 import { Button } from '../components/parts/buttons/Button'
 import { SocialButton } from '../components/parts/buttons/SocialButton'
 import { InputField } from '../components/template/forms/InputField'
+import { Head } from '../components/parts/texts/Head'
 
 export const Auth: FC = () => {
   const [count, setCount] = useState(0)
@@ -14,6 +16,8 @@ export const Auth: FC = () => {
       <br />
       <InputField label="test" />
       <Button onClick={() => setCount(count + 1)}>Login</Button>
+      <br />
+      <Head level={1}>Headたぐ</Head>
     </div>
   )
 }

--- a/src/styles/layouts/global.ts
+++ b/src/styles/layouts/global.ts
@@ -14,6 +14,10 @@ export const globalTheme: Theme = {
     text: {
       primary: '#000',
       secondary: '#575756',
+      tertiary: '#757575',
+      quaternary: '',
+      quinary: '',
+      senary: '',
     },
   },
   margin: {
@@ -30,5 +34,14 @@ export const globalStyle = css`
   ${emotionReset}
   html {
     font-family: '游ゴシック体‘, YuGothic, ‘游ゴシック’, ‘Yu Gothic’, sans-serif';
+  }
+
+  h1 {
+    font-size: 25px;
+  }
+
+  h3 {
+    color: #757575;
+    font-size: 19px;
   }
 `

--- a/src/styles/layouts/header.ts
+++ b/src/styles/layouts/header.ts
@@ -1,6 +1,6 @@
 import { css, SerializedStyles, Theme } from '@emotion/react'
 
-export const headerStyle = ({ margin, height }: Theme): SerializedStyles =>
+export const headerStyle = ({ height }: Theme): SerializedStyles =>
   css({
     display: 'flex',
     justifyContent: 'center',
@@ -20,10 +20,6 @@ export const headerStyle = ({ margin, height }: Theme): SerializedStyles =>
       boxSizing: 'border-box',
     },
   })
-
-export const headerTitleStyle = css({
-  fontSize: '25px',
-})
 
 export const headerNavStyle = css({
   display: 'flex',


### PR DESCRIPTION
## 実装

- hタグ用コンポーネントを「Head」として作成
- levelによってタグの状態を切り替える
- スタイルが決まりきっていないのでおいおい付け足す必要がある
- TODOとして「useDisclosure」の綴りミス追記
- Gitmoji採用